### PR TITLE
Change lastBuildDate source to time.Now

### DIFF
--- a/layouts/podcasts/rss.xml
+++ b/layouts/podcasts/rss.xml
@@ -31,9 +31,7 @@
         <webMaster>{{.}}{{ with site.Author.name }} ({{.}}){{end}}</webMaster>
     {{end}}
     <copyright>{{ site.Params.podcast_copyright }}</copyright>
-    {{ if not .Date.IsZero }}
-        <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
-    {{ end }}
+    <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     <itunes:category text="Technology" />
     <itunes:author>{{ site.Author.name }}</itunes:author>
     <itunes:subtitle>{{ site.Params.description }}</itunes:subtitle>


### PR DESCRIPTION
Говорят что в Podcast Addict на андроиде сейчас наши новые выпуски могут сползти вниз в ленте, потому что мы релизимся иногда сильно позже даты записи. Предполагаем, что lastBuildDate с time.Now решит эту проблему. Но это не точно. В любом случае хуже не должно быть.