### PR TITLE
Perestanovochki

### DIFF
--- a/layouts/partials/podcasts_all.html
+++ b/layouts/partials/podcasts_all.html
@@ -3,12 +3,17 @@
 <div class="podcasts-list podcasts-grid">
   {{ range (where .page.Site.RegularPages.ByDate.Reverse "Section" $section ) }}
   <a href="{{ .RelPermalink }}" class="podcasts-grid__item">
-    <div class="podcasts-grid__image"><img src="{{ .Params.image }}" /></div>
+    <div class="podcasts-grid__image">
+      <div class="podcasts-grid__duration">
+        {{ replaceRE `^[0:]*` "" .Params.duration }}
+      </div>
+      <img src="{{ .Params.image }}" />
+    </div>
     <div class="podcasts-grid__description-wrapper">
-      <div class="podcasts-grid__description">{{ .Params.summary }}</div>
       <div class="podcasts-grid__date">
         {{ time.Format "January 2, 2006" .Params.date }}
       </div>
+      <div class="podcasts-grid__description">{{ .Params.summary }}</div>
     </div>
   </a>
   {{ end }}

--- a/layouts/partials/podcasts_last.html
+++ b/layouts/partials/podcasts_last.html
@@ -4,12 +4,17 @@
   {{ range first 12 (where .page.Site.RegularPages.ByDate.Reverse "Section"
   $section ) }}
   <a href="{{ .RelPermalink }}" class="podcasts-grid__item">
-    <div class="podcasts-grid__image"><img src="{{ .Params.image }}" /></div>
+    <div class="podcasts-grid__image">
+      <div class="podcasts-grid__duration">
+        {{ replaceRE `^[0:]*` "" .Params.duration }}
+      </div>
+      <img src="{{ .Params.image }}" />
+    </div>
     <div class="podcasts-grid__description-wrapper">
-      <div class="podcasts-grid__description">{{ .Params.summary }}</div>
       <div class="podcasts-grid__date">
         {{ time.Format "January 2, 2006" .Params.date }}
       </div>
+      <div class="podcasts-grid__description">{{ .Params.summary }}</div>
     </div>
   </a>
   {{ end }}

--- a/themes/DoubleIvan/assets/css/main.less
+++ b/themes/DoubleIvan/assets/css/main.less
@@ -417,17 +417,28 @@ a {
   border-radius: 20px;
   background-color: var(--white);
   overflow: hidden;
+  position: relative;
 
   @media @tablet {
     border-radius: 10px;
   }
 }
 
+.podcasts-grid__duration {
+  .text-xs();
+  background-color: rgba(0, 0, 0, 0.6);
+  border-radius: 12px;
+  color: var(--white);
+  padding: 4px 8px;
+  position: absolute;
+  right: 8px;
+  top: 8px;
+}
+
 .podcasts-grid__description-wrapper {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  justify-content: space-between;
 }
 
 .podcasts-grid__description {
@@ -442,6 +453,7 @@ a {
 
 .podcasts-grid__date {
   .text-xs();
+  margin-top: 10px;
   opacity: 0.5;
 }
 
@@ -526,6 +538,14 @@ a {
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
+
+  a {
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 
   @media @tablet {
     gap: 10px;


### PR DESCRIPTION
Небольшие изменения в списках:
- Даты поднял над описаниями. Теперь они более органично смотрятся и не возникает ощущения, что относятся к тем подкастам, которые расположены под ними.
- Добавил продолжительность подкастов на обложки, чтобы можно было сразу выбирать что-то под настроение и наличие времени.

<img width="320" alt="image" src="https://github.com/biozz/doubleivan.ru/assets/6529684/5b76b6ab-f7f3-4003-b67b-aa472ecb94b9">

Плюс добавил нижнее подчёркиванием ссылкам на странице подкаста (блоки с описанием и ссылками), чтоб не непонятная мешанина была, а видно стало, куда тут можно нажимать.

<img width="320" alt="image" src="https://github.com/biozz/doubleivan.ru/assets/6529684/9a2fa81c-e253-4a7b-86e0-8df3a80a9a5d">
