### PR TITLE
Add telegram comments

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,4 @@
 baseURL: "https://doubleivan.ru/"
-author:
-  name: "Ivan Chernov, Ivan Elfimov"
-  email: "ivan.elfimov@ostrovok.ru"
 languageCode: "ru-ru"
 title: "Два Ивана"
 theme: "DoubleIvan"
@@ -14,6 +11,9 @@ menu:
       weight: 10
 
 params:
+  author:
+    name: "Ivan Chernov, Ivan Elfimov"
+    email: "ivan.elfimov@ostrovok.ru"
   title: "Два Ивана (название обсуждается)"
   description: "Разработчики из Ostrovok.ru разговаривают про Python и IT"
   podcast_copyright: "Creative Commons - Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0) License."

--- a/layouts/podcasts/single.html
+++ b/layouts/podcasts/single.html
@@ -32,6 +32,18 @@
       <h4 class="h4">Таймкоды</h4>
       <div class="single__timecodes-list">{{ partial "timecodes.html" . }}</div>
     </div>
+    {{ if .Params.telegram_discussion }}
+    <div class="block_white single__comments">
+      <script
+        async
+        src="https://telegram.org/js/telegram-widget.js?22"
+        data-telegram-discussion="{{ .Params.telegram_discussion }}"
+        data-comments-limit="10"
+        data-color="0F5DE4"
+        data-dark="0"
+      ></script>
+    </div>
+    {{ end }}
   </div>
 </div>
 

--- a/themes/DoubleIvan/assets/css/main.less
+++ b/themes/DoubleIvan/assets/css/main.less
@@ -634,6 +634,10 @@ a {
   }
 }
 
+.single__comments {
+    width: 100%;
+}
+
 audio {
   display: block;
 }


### PR DESCRIPTION

Чтобы работало, надо указать во front matter поста ссылку на пост:

```yaml
telegram_discussion: "admeto/123"
```

Так мы будем использовать t.me/ostrovok_tech, мы не можем подключить автоматическую загрузку комментов, как пишут в мануале - https://core.telegram.org/widgets/discussion. То есть придется добавлять после ссылку на комменты после поста в телеге. Или еще как-то.

Пример того как выглядит с комментариями:

![Screenshot 2024-03-19 at 20 36 37](https://github.com/biozz/doubleivan.ru/assets/3424811/6b65ab24-3d65-4e36-bff4-723d985bd5bc)

Из оффтоп изменений - перенос авторов в блок params, потому что hugo предупредил.